### PR TITLE
TS-14 BUG - TeamMembers and PlayerPositions duplicated in Player Seeds

### DIFF
--- a/prisma/seeds/players.ts
+++ b/prisma/seeds/players.ts
@@ -570,7 +570,7 @@ const seedPlayers = (prisma: PrismaClient, positions: Position[], teams: Team[])
     await prisma.player.upsert({
       where: { key: player.key },
       create: player,
-      update: player,
+      update: {},
     })
   ))
 

--- a/prisma/seeds/players.ts
+++ b/prisma/seeds/players.ts
@@ -25,9 +25,10 @@ const seedPlayers = (prisma: PrismaClient, positions: Position[], teams: Team[])
         }
       },
       playerPositions: {
-        create: {
-          positionId: outsideBackId,
-        }
+        create: [
+          { positionId: centreId },
+          { positionId: outsideBackId },
+        ],
       },
     },
     {
@@ -57,9 +58,10 @@ const seedPlayers = (prisma: PrismaClient, positions: Position[], teams: Team[])
         }
       },
       playerPositions: {
-        create: {
-          positionId: flyhalfId,
-        }
+        create: [
+          { positionId: flyhalfId },
+          { positionId: outsideBackId },
+        ]
       },
     },
     {
@@ -153,9 +155,10 @@ const seedPlayers = (prisma: PrismaClient, positions: Position[], teams: Team[])
         }
       },
       playerPositions: {
-        create: {
-          positionId: centreId,
-        }
+        create: [
+          { positionId: centreId },
+          { positionId: outsideBackId },
+        ]
       },
     },
     {
@@ -185,9 +188,10 @@ const seedPlayers = (prisma: PrismaClient, positions: Position[], teams: Team[])
         }
       },
       playerPositions: {
-        create: {
-          positionId: centreId,
-        }
+        create: [
+          { positionId: centreId },
+          { positionId: outsideBackId },
+        ]
       },
     },
     {
@@ -409,9 +413,10 @@ const seedPlayers = (prisma: PrismaClient, positions: Position[], teams: Team[])
         }
       },
       playerPositions: {
-        create: {
-          positionId: backRowId,
-        }
+        create: [
+          { positionId: lockId },
+          { positionId: backRowId },
+        ]
       },
     },
     {
@@ -505,9 +510,10 @@ const seedPlayers = (prisma: PrismaClient, positions: Position[], teams: Team[])
         }
       },
       playerPositions: {
-        create: {
-          positionId: lockId,
-        },
+        create: [
+          { positionId: lockId },
+          { positionId: backRowId },
+        ]
       },
     },
     {

--- a/prisma/seeds/positions.ts
+++ b/prisma/seeds/positions.ts
@@ -68,7 +68,7 @@ const seedPositions = (prisma: PrismaClient, sports: Sport[]) => {
         key: position.key,
       },
       create: position,
-      update: position,
+      update: {},
     })
   ))
 

--- a/prisma/seeds/sports.ts
+++ b/prisma/seeds/sports.ts
@@ -16,7 +16,7 @@ const seedSports = (prisma: PrismaClient) => {
     await prisma.sport.upsert({
       where: { key: sport.key },
       create: sport,
-      update: sport,
+      update: {},
     })
   ))
 

--- a/prisma/seeds/teams.ts
+++ b/prisma/seeds/teams.ts
@@ -15,7 +15,7 @@ const seedTeams = (prisma: PrismaClient, sports: Sport[]) => {
     await prisma.team.upsert({
       where: { key: team.key },
       create: team,
-      update: team,
+      update: {},
     })
   ))
 


### PR DESCRIPTION
Duplication of seeds ✅ 
Added Multiple player position seeds ✅ 

Ok to solve the duplication of seeds, we just needed to pass an empty object to update which essentially makes prisma upsert behave like a find or create.

`    await prisma.team.upsert({
      where: { key: team.key },
      create: team,
      update: {},
    })`

I dropped my db with:
    
`yarn prisma migrate reset`

I actually received an error with this but it did drop my db. It's meant to drop the db, push the schema, apply any migrations and run the seeds all at once [https://www.prisma.io/docs/reference/api-reference/command-reference#migrate-reset](url)

So instead I then just re pushed the schema
`yarn prisma db push`

and then run seeds
`yarn prisma db seed`

You'll notice now there is also 40 playerPosition records in the playerPosition join table.
This is because there are 6 players that have been seeded with two positions.

