### PR TITLE
TS-33 BUG - API requests incorrect in Production

### DIFF
--- a/src/app/api/base.ts
+++ b/src/app/api/base.ts
@@ -1,6 +1,6 @@
 const apiUrls = {
   development: 'http://localhost:3000/api',
-  production: '',
+  production: 'https://teamsheet.online/api',
   test: '',
 }
 


### PR DESCRIPTION
note that we are still finding this url by process.env.NODE_ENV so we need to make sure this is being set in prod