### PR TITLE
TS-36 BUG - Scrolling disabled in Production

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,7 @@ const nextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
+  reactStrictMode: false,
   async headers() {
     return [
       {

--- a/src/app/shared/modals/BaseModal.tsx
+++ b/src/app/shared/modals/BaseModal.tsx
@@ -38,7 +38,8 @@ const BaseModal = (props: BaseModalProps) => {
 
   // Disable scrolling on screen behind the modal
   useEffect(() => {
-    document.body.classList.toggle('overflow-hidden')
+    if (showModal) document.body.classList.add('overflow-hidden')
+    if (!showModal) document.body.classList.remove('overflow-hidden')
   }, [showModal])
 
   if (!showModal) return null


### PR DESCRIPTION
i believe the cause of the bug is related to React Strict Mode, which behaves differently in dev and prod

https://react.dev/blog/2022/03/29/react-v18#new-strict-mode-behaviors

Strict Mode is on by default in Next, and causes our useEffect to run twice, which toggles `overflow-hidden` on and off as soon as the page loads, With the new conditions i have added, it should only add `overflow-hidden` is a modal is open.