### PR TITLE
TS-58 BUG - Update TeamSheet Urls with new routes

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,7 +33,7 @@ model Competition {
   updatedAt DateTime @updatedAt
 
   competitionTeams CompetitionTeam[]
-  teamSheeets TeamSheet[]
+  teamSheets TeamSheet[]
 
   @@map("competitions")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,7 @@ model Competition {
   updatedAt DateTime @updatedAt
 
   competitionTeams CompetitionTeam[]
+  teamSheeets TeamSheet[]
 
   @@map("competitions")
 }
@@ -74,6 +75,8 @@ model TeamSheet {
   editId String @default(uuid()) @unique
   shareId String @default(uuid()) @unique
   title String?
+  competition Competition @relation(fields: [competitionId], references: [id])
+  competitionId Int
   team Team @relation(fields: [teamId], references: [id])
   teamId Int
   user User? @relation(fields: [userId], references: [id])

--- a/src/app/shared/components/ShareBar/index.tsx
+++ b/src/app/shared/components/ShareBar/index.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { usePathname, useRouter } from 'next/navigation'
+import { useParams, useRouter } from 'next/navigation'
 
 import type { TeamSheet } from '@prisma/client'
 
@@ -13,22 +13,26 @@ import { PlayerWithPositions } from '@types'
 type Router = ReturnType<typeof useRouter>
 
 type CreateAndRedirectParams = {
-  teamSheet: TeamSheet,
+  competitionKey: string,
   router: Router,
+  sportKey: string,
+  teamKey: string,
+  teamSheet: TeamSheet,
 }
 
 const createTeamSheetAndRedirect = async (params: CreateAndRedirectParams) => {
-  const { router, teamSheet } = params
+  const { competitionKey, sportKey, teamKey, router, teamSheet } = params
 
   const data = teamSheet.data as { [key: string]: PlayerWithPositions }
 
   const payload = {
+    competitionId: teamSheet.competitionId,
     data,
     teamId: teamSheet.teamId,
   }
 
   const newTeamSheet = await createTeamSheet(payload)
-  router.push(`/rugby/wallabies?teamSheetId=${newTeamSheet.editId}`)
+  router.push(`/sport/${sportKey}/${competitionKey}/${teamKey}?teamSheetId=${newTeamSheet.editId}`)
 }
 
 interface ShareBarProps {
@@ -38,14 +42,18 @@ interface ShareBarProps {
 const ShareBar = (props: ShareBarProps) => {
   const { teamSheet } = props
 
-  const router = useRouter()
+  const params: { competition: string, sport: string, team: string } = useParams()
+  const {
+    competition: competitionKey,
+    sport: sportKey,
+    team: teamKey,
+  } = params
 
-  const pathname = usePathname()
-  const sportHref = pathname.split('/')[1]
+  const router = useRouter()
 
   return (
     <div className="flex p-3">
-      <Link href={`/${sportHref}`}>
+      <Link href={`/sport/${sportKey}`}>
         <div className="p-2 border rounded bg-green-500 hover:bg-green-600 text-white font-semibold">
           Create your own
         </div>
@@ -53,7 +61,7 @@ const ShareBar = (props: ShareBarProps) => {
 
       <Button
         className="ml-2 w-[190px]"
-        onClick={() => createTeamSheetAndRedirect({ teamSheet, router })}
+        onClick={() => createTeamSheetAndRedirect({ competitionKey, sportKey, teamKey, teamSheet, router })}
         text="Duplicate Team Sheet"
         variant="create"
       />

--- a/src/app/shared/contexts/teamContext.ts
+++ b/src/app/shared/contexts/teamContext.ts
@@ -1,7 +1,7 @@
 import { createContext } from 'react'
 import type { Dispatch, SetStateAction } from 'react'
 
-import type { Team, TeamSheet } from '@prisma/client'
+import type { Competition, Team, TeamSheet } from '@prisma/client'
 
 import type { PlayerWithPositions } from '@types'
 
@@ -12,6 +12,7 @@ type TeamContext = {
     setSelectedPositions: Dispatch<SetStateAction<string[]>>,
     setSelectedTeamSheetLayoutId: Dispatch<SetStateAction<string | undefined>>,
   },
+  competition: Competition,
   filteredPlayers?: PlayerWithPositions[],
   selectedTeamSheetLayoutId?: string,
   showModal?: boolean,

--- a/src/app/shared/modals/SelectPlayerModal/index.tsx
+++ b/src/app/shared/modals/SelectPlayerModal/index.tsx
@@ -40,6 +40,7 @@ const handlePlayerSelect = async (params: HandlePlayerSelectParams) => {
   const payload = {
     data: { [teamSheetLayoutId]: player },
     teamId,
+    // now need competitionId
   }
 
   if (teamSheet){
@@ -69,6 +70,7 @@ const SelectPlayerModal = () => {
   const teamContextValue = useContext(TeamContext)
   const {
     callbacks,
+    competition,
     filteredPlayers,
     selectedTeamSheetLayoutId,
     showModal,

--- a/src/app/shared/modals/SelectPlayerModal/index.tsx
+++ b/src/app/shared/modals/SelectPlayerModal/index.tsx
@@ -20,6 +20,7 @@ type Router = ReturnType<typeof useRouter>
 
 type HandlePlayerSelectParams = {
   callbacks: { closeModal: () => void },
+  competitionId: number,
   player: PlayerWithPositions,
   router: Router,
   teamId: number,
@@ -30,6 +31,7 @@ type HandlePlayerSelectParams = {
 const handlePlayerSelect = async (params: HandlePlayerSelectParams) => {
   const {
     callbacks: { closeModal },
+    competitionId,
     player,
     router,
     teamId,
@@ -38,9 +40,9 @@ const handlePlayerSelect = async (params: HandlePlayerSelectParams) => {
   } = params
 
   const payload = {
+    competitionId,
     data: { [teamSheetLayoutId]: player },
     teamId,
-    // now need competitionId
   }
 
   if (teamSheet){
@@ -94,6 +96,7 @@ const SelectPlayerModal = () => {
             disabled={isAlreadyAssigned}
             onClick={isAlreadyAssigned ? undefined : () => handlePlayerSelect({
               callbacks: { closeModal: closeModal! },
+              competitionId: competition.id,
               player,
               router,
               teamId: team!.id,

--- a/src/app/shared/types/index.ts
+++ b/src/app/shared/types/index.ts
@@ -31,3 +31,14 @@ export type TeamSheetWithRelations = Prisma.TeamSheetGetPayload<
     },
   }
 >
+
+export type TeamSheetWithCompetitionSportAndTeam = Prisma.TeamSheetGetPayload<
+  {
+    include: {
+      competition: {
+        include: { sport: true },
+      },
+      team: true,
+    },
+  }
+>

--- a/src/app/sport/[sport]/[competition]/[team]/TeamContent.tsx
+++ b/src/app/sport/[sport]/[competition]/[team]/TeamContent.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 
-import { Team, TeamSheet } from '@prisma/client'
+import { Competition, Team, TeamSheet } from '@prisma/client'
 
 import TeamContext from '@contexts/teamContext'
 
@@ -12,13 +12,14 @@ import type { PlayerWithPositions } from '@types'
 
 interface TeamContentProps {
   children: React.ReactNode,
+  competition: Competition,
   players: PlayerWithPositions[],
   team: Team,
   teamSheet: TeamSheet | null,
 }
 
 const TeamContent = (props: TeamContentProps) => {
-  const { children, players, team, teamSheet } = props
+  const { children, competition, players, team, teamSheet } = props
 
   const [selectedPositions, setSelectedPositions] = useState<string[]>([])
   const [selectedTeamSheetLayoutId, setSelectedTeamSheetLayoutId] = useState<string>()
@@ -33,6 +34,7 @@ const TeamContent = (props: TeamContentProps) => {
       setSelectedPositions,
       setSelectedTeamSheetLayoutId,
     },
+    competition,
     filteredPlayers,
     selectedTeamSheetLayoutId,
     showModal,

--- a/src/app/sport/[sport]/[competition]/[team]/page.tsx
+++ b/src/app/sport/[sport]/[competition]/[team]/page.tsx
@@ -16,15 +16,28 @@ import type { PlayerWithPositions } from '@types'
 import TeamContent from './TeamContent'
 
 type PageProps = {
-  params: { team: string },
+  params: {
+    competition: string,
+    team: string,
+  },
   searchParams: { teamSheetId?: string },
 }
 
 const Page = async (props: PageProps) => {
   const {
-    params: { team: teamkey },
+    params: {
+      competition: competitionKey,
+      team: teamkey,
+    },
     searchParams: { teamSheetId },
   } = props
+
+  const competition = await prisma.competition.findUnique({
+    where: {
+      key: competitionKey,
+    },
+  })
+  if (!competition) return notFound()
 
   const team = await prisma.team.findUnique({
     where: {
@@ -66,7 +79,7 @@ const Page = async (props: PageProps) => {
   const isTeamSheetComplete = !!data && Object.keys(data).length === teamSize
 
   return (
-    <TeamContent players={players} team={team} teamSheet={teamSheet}>
+    <TeamContent competition={competition} players={players} team={team} teamSheet={teamSheet}>
       <TopBar />
       
       {hasTeamSheet && isTeamSheetComplete && <NameForm teamSheet={teamSheet} />}

--- a/src/app/sport/[sport]/[competition]/[team]/share/page.tsx
+++ b/src/app/sport/[sport]/[competition]/[team]/share/page.tsx
@@ -10,13 +10,21 @@ import ShareBar from '@components/ShareBar'
 import ShareContent from './ShareContent'
 
 type PageProps = {
-  params: { team: string },
+  params: {
+    competition: string,
+    sport: string,
+    team: string,
+  },
   searchParams: { teamSheetId?: string },
 }
 
 export const generateMetadata = async (props: PageProps): Promise<Metadata> => {
   const {
-    params: { team },
+    params: {
+      competition: competitionKey,
+      sport: sportKey,
+      team: teamkey,
+    },
     searchParams: { teamSheetId },
   } = props
 
@@ -46,7 +54,7 @@ export const generateMetadata = async (props: PageProps): Promise<Metadata> => {
       siteName: 'Teamsheet',
       title: teamSheet?.title || `My ${teamSheet?.team?.title}`,
       type: 'website',
-      url: `/rugby/${team}/share?teamSheetId=${teamSheetId}`
+      url: `/sport/${sportKey}/${competitionKey}/${teamkey}/share?teamSheetId=${teamSheetId}`
     },
     twitter: {
       card: 'summary_large_image',

--- a/src/app/teamSheets/_TeamSheetListItem/index.tsx
+++ b/src/app/teamSheets/_TeamSheetListItem/index.tsx
@@ -3,27 +3,31 @@ import { faEdit, faShareFromSquare } from '@fortawesome/free-solid-svg-icons'
 
 import Link from 'next/link'
 
-import type { TeamSheetWithRelations } from '@types'
+import type { TeamSheetWithCompetitionSportAndTeam } from '@types'
 
 interface TeamSheetListItemProps {
-  teamSheet: TeamSheetWithRelations,
+  teamSheet: TeamSheetWithCompetitionSportAndTeam,
 }
 
 const TeamSheetListItem = (props: TeamSheetListItemProps) => {
-  const { teamSheet } = props || {}
-  const { editId, shareId, team, title: teamSheetTitle } = teamSheet
-  const { competitionTeams, key: teamKey, title: teamTitle } = team
-
-  const hasMultipleCompetitionTeams = competitionTeams.length > 1
-  const firstCompetitionTeam = competitionTeams[0]
-  const { 
-    competition: {
-      title: competitionTitle,
-      sport: {
-        key: sportKey,
+  const {
+    teamSheet: {
+      competition: {
+        key: competitionKey,
+        sport: {
+          key: sportKey,
+        },
+        title: competitionTitle,
       },
-    },
-  } = firstCompetitionTeam
+      editId,
+      shareId,
+      team: {
+        key: teamKey,
+        title: teamTitle,
+      },
+      title: teamSheetTitle,
+    }
+  } = props
 
   return (
     <div className="flex border rounded mb-3 p-4 w-full justify-between">
@@ -33,23 +37,19 @@ const TeamSheetListItem = (props: TeamSheetListItemProps) => {
         </div>
         
         <div className="flex text-sm text-slate-400">
-          <div>{teamTitle}</div>
-
-          {!hasMultipleCompetitionTeams && (
-            <div>, {competitionTitle}</div>
-          )}
+          {teamTitle}, {competitionTitle}
         </div>
       </div>
 
       <div className="flex items-center">
-        <Link href={`${process.env.NEXT_PUBLIC_VERCEL_URL}/${sportKey}/${teamKey}/share?teamSheetId=${shareId}`}>
+        <Link href={`${process.env.NEXT_PUBLIC_VERCEL_URL}/sport/${sportKey}/${competitionKey}/${teamKey}/share?teamSheetId=${shareId}`}>
           <FontAwesomeIcon
             className="cursor-pointer ml-3 hover:text-cyan-400"
             icon={faShareFromSquare}
           />
         </Link>
 
-        <Link href={`${process.env.NEXT_PUBLIC_VERCEL_URL}/${sportKey}/${teamKey}?teamSheetId=${editId}`}>
+        <Link href={`${process.env.NEXT_PUBLIC_VERCEL_URL}/sport/${sportKey}/${competitionKey}/${teamKey}?teamSheetId=${editId}`}>
           <FontAwesomeIcon
             className="cursor-pointer ml-3 hover:text-cyan-400"   
             icon={faEdit}

--- a/src/app/teamSheets/page.tsx
+++ b/src/app/teamSheets/page.tsx
@@ -10,7 +10,7 @@ import { findOrCreateUser } from '@functions/user'
 
 import PageHeader from '@components/PageHeader'
 
-import type { TeamSheetWithRelations } from '@types'
+import type { TeamSheetWithCompetitionSportAndTeam } from '@types'
 
 import TeamSheetListItem from './_TeamSheetListItem'
 
@@ -19,31 +19,22 @@ const Page = async () => {
   const kindeCurrentUser = await getUser()
 
   const currentUser = await findOrCreateUser(kindeCurrentUser)
-  if (!currentUser?.id) redirect('/#')
+  if (!currentUser?.id) redirect('/')
 
-  const userTeamSheets = await prisma.teamSheet.findMany({
+  const teamSheets = await prisma.teamSheet.findMany({
     where: {
       userId: currentUser?.id,
     },
     include: {
-      team: {
-        include: {
-          competitionTeams: {
-            include: {
-              competition: {
-                include: {
-                  sport: true,
-                },
-              },
-            },
-          },
-        },
+      competition: {
+        include: { sport: true },
       },
+      team: true,
     },
     orderBy: { updatedAt: 'desc' },
   })
 
-  const hasTeamSheets = !!userTeamSheets?.length
+  const hasTeamSheets = !!teamSheets?.length
 
   return (
     <div className="flex flex-col max-w-column p-3">
@@ -54,7 +45,7 @@ const Page = async () => {
       
       {hasTeamSheets && (
         <div>
-          {userTeamSheets.map((teamSheet: TeamSheetWithRelations) => (
+          {teamSheets.map((teamSheet: TeamSheetWithCompetitionSportAndTeam) => (
             <TeamSheetListItem key={teamSheet.id} teamSheet={teamSheet} />
           ))}
         </div>

--- a/src/app/teamSheets/page.tsx
+++ b/src/app/teamSheets/page.tsx
@@ -10,8 +10,6 @@ import { findOrCreateUser } from '@functions/user'
 
 import PageHeader from '@components/PageHeader'
 
-import type { TeamSheetWithCompetitionSportAndTeam } from '@types'
-
 import TeamSheetListItem from './_TeamSheetListItem'
 
 const Page = async () => {
@@ -42,14 +40,10 @@ const Page = async () => {
         icon={faUsersRectangle}
         title="My Team Sheets"
       />
-      
-      {hasTeamSheets && (
-        <div>
-          {teamSheets.map((teamSheet: TeamSheetWithCompetitionSportAndTeam) => (
-            <TeamSheetListItem key={teamSheet.id} teamSheet={teamSheet} />
-          ))}
-        </div>
-      )}
+
+      {hasTeamSheets && teamSheets.map(teamSheet => (
+        <TeamSheetListItem key={teamSheet.id} teamSheet={teamSheet} />
+      ))}
     </div>
   )
 }


### PR DESCRIPTION
- i chose to add a `competitionId` column to the teamsheet
- Without that, a teamsheet references a team which can have multiple competitions. So when we are trying to generate the url, we don't know which competition to use
-  With a competition saved on the teamsheet on create, we now always know which competition the teamsheet is for
- This PR requires the entire db to be dropped again, which is why the deploy is failing