### PR TITLE
TS-64 IMPROVEMENT - Update Share Page with Edit Team Sheet

### DIFF
--- a/src/app/globalContext.tsx
+++ b/src/app/globalContext.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { createContext, useContext } from 'react'
+
+import { useKindeBrowserClient } from "@kinde-oss/kinde-auth-nextjs"
+
+import { findOrCreateUser } from '@functions/user'
+
+import type { User } from '@prisma/client'
+
+type GlobalContextProps = {
+  currentUser?: User,
+}
+
+const GlobalContext = createContext<GlobalContextProps>({})
+
+export function GlobalContextProvider({ children }){
+  const { user } = useKindeBrowserClient()
+  console.log('user', user)
+
+  const currentUser = findOrCreateUser(user)
+  // console.log('currentUser', currentUser)
+
+  return (
+    <GlobalContext.Provider value={{ currentUser }}>
+      {children}
+    </GlobalContext.Provider>
+  )
+}
+
+export const useGlobalContext = () => useContext(GlobalContext)

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,13 @@ import type { Metadata } from 'next'
 import Script from 'next/script'
 import { Inter } from 'next/font/google'
 import localFont from "next/font/local"
+
+import { getKindeServerSession } from '@kinde-oss/kinde-auth-nextjs/server'
+
+import { findOrCreateUser } from '@functions/user'
+
+import { GlobalContextProvider } from './globalContext'
+
 import './globals.css'
 
 // Load fontawesome css at the root of the app to stop 'flashing' icon
@@ -58,19 +65,26 @@ export const metadata: Metadata = {
   }
 }
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
+  const { getUser } = getKindeServerSession()
+  const kindeUser = await getUser()
+
+  findOrCreateUser(kindeUser)
+
   return (
     <html lang="en">
       <body className={`${futura.className} ${inter.className} flex flex-col items-center`}>
-        <NavBar title="TEAMSHEET" />
+        <GlobalContextProvider>
+          <NavBar title="TEAMSHEET" />
 
-        <div className="max-w-column w-full">
-          {children}
-        </div>
+          <div className="max-w-column w-full">
+            {children}
+          </div>
+        </GlobalContextProvider>
       </body>
       <Script src="https://platform.twitter.com/widgets.js" />
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,5 @@
 import { redirect } from 'next/navigation'
 
-import { getKindeServerSession } from '@kinde-oss/kinde-auth-nextjs/server'
-
-import { findOrCreateUser } from '@functions/user'
-
 export default async function Home() {
-  const { getUser } = getKindeServerSession()
-  const kindeUser = await getUser()
-
-  findOrCreateUser(kindeUser)
-
   redirect('/sport/rugby')
 }

--- a/src/app/shared/components/ShareBar/index.tsx
+++ b/src/app/shared/components/ShareBar/index.tsx
@@ -1,11 +1,15 @@
 'use client'
 
+import { useContext } from 'react'
+
 import Link from 'next/link'
 import { useParams, useRouter } from 'next/navigation'
 
 import type { TeamSheet } from '@prisma/client'
 
 import { createTeamSheet } from '@actions/teamSheet'
+
+import { useGlobalContext } from '../../../globalContext'
 
 import Button from '@components/Button'
 import { PlayerWithPositions } from '@types'
@@ -51,6 +55,10 @@ const ShareBar = (props: ShareBarProps) => {
   } = params
 
   const router = useRouter()
+
+  const globalContext = useGlobalContext()
+  const { currentUser } = globalContext
+  console.log('currentUser', currentUser)
 
   // WIP
   // Can't use just editId & userId here as need to ensure its the current users team sheet to allow them to edit it!

--- a/src/app/shared/components/ShareBar/index.tsx
+++ b/src/app/shared/components/ShareBar/index.tsx
@@ -41,6 +41,7 @@ interface ShareBarProps {
 
 const ShareBar = (props: ShareBarProps) => {
   const { teamSheet } = props
+  const { editId, userId } = teamSheet
 
   const params: { competition: string, sport: string, team: string } = useParams()
   const {
@@ -51,19 +52,26 @@ const ShareBar = (props: ShareBarProps) => {
 
   const router = useRouter()
 
+  // WIP
+  // Can't use just editId & userId here as need to ensure its the current users team sheet to allow them to edit it!
+
   return (
     <div className="flex p-3">
-      <Link href={`/sport/${sportKey}`}>
+      <Link
+        href={userId ?
+        `/sport/${sportKey}/${competitionKey}/${teamKey}?teamSheetId=${editId}`
+        : `/sport/${sportKey}`
+        }
+      >
         <div className="p-2 border rounded bg-green-500 hover:bg-green-600 text-white font-semibold">
-          Create your own
+          {userId ? "Edit Team Sheet" : "+ Create Your Own"}
         </div>
       </Link>
 
       <Button
-        className="ml-2 w-[190px]"
+        className="ml-2 w-[190px] font-semibold"
         onClick={() => createTeamSheetAndRedirect({ competitionKey, sportKey, teamKey, teamSheet, router })}
-        text="Duplicate Team Sheet"
-        variant="create"
+        text="+ Duplicate Team Sheet"
       />
     </div>
   )


### PR DESCRIPTION
WIP:
_Two things here_
**1st** - just updated the look of buttons. Updated to have a "+" for Create or Duplicate buttons. Now realize I want the edit icon for an Edit button. Also updated the colour of the Duplicate button - I think the Create Team Sheet and Duplicate Teamsheet should have look different/. I've gone with different colours like a createPrimary and createSecondary but maybe the duplicate button should be the same colour but just a ghost button (green border and text, white background)? Thoughts?

**2nd** - Reason for this this PR is described in the ticket
"When user is logged in and visiting the share page for one of their own teamsheets, updating the "Create Your Own" button to instead be an "Edit Team Sheet" button so that user can go back to the edit page.

Currently no way to navigate back to the edit page other than going back to my team sheets page and clicking edit link."

What I've currently done won't work as it will show the edit link to any logged in user.

Need to show the Edit teamsheet button if a) the user is logged in and b) that teamsheet belongs to that user. 

Thinking we need a useCurrentUser hook and then compare that userId against the userId on the teamsheet. 

Will update.

..

If not Logged in:
<img width="1083" alt="Screenshot 2024-04-01 at 11 34 06 pm" src="https://github.com/dcarg/teamsheet/assets/39669538/b9e518b4-68ba-456c-94c7-d0a01095c2d5">


If Logged in:
<img width="1059" alt="Screenshot 2024-04-01 at 11 33 44 pm" src="https://github.com/dcarg/teamsheet/assets/39669538/526ee5aa-3165-40a3-85a7-864aa9acbe07">
