### PR TITLE
TS-68 IMPROVEMENT - Add Admin column to User Table

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -151,6 +151,7 @@ model User {
   id Int @id @default(autoincrement())
   email String?
   firstname String?
+  isAdmin Boolean @default(false)
   lastname String?
   username String?
 


### PR DESCRIPTION
- this is essentially having 2 roles: admin and non-admin
- will we ever have more than 2 roles? if so we should put in a roles table instead of this