### PR TITLE
TS-54 BUG - Field PlayerCard size & text ellipsis

### DIFF
--- a/src/app/shared/components/Field/PlayerCard/index.tsx
+++ b/src/app/shared/components/Field/PlayerCard/index.tsx
@@ -64,7 +64,7 @@ const PlayerCard = (props: PlayerCardProps) => {
           </div>
         )}
 
-        <div className="font-bold truncate text-xs text-center mt-1">
+        <div className="font-bold truncate text-xs text-center mt-1 text-ellipsis w-20">
           {isPlayerSelected ? getPlayerTitle(player) : positionTitle}
         </div>
       </div>


### PR DESCRIPTION
Just added missing ellipsis

Have given the player cards a fixed width of 80px for the ellipsis. 

Not sure if we should just have a larger fixed width for desktop?

<img width="286" alt="Screenshot 2024-04-09 at 10 16 50 pm" src="https://github.com/dcarg/teamsheet/assets/39669538/783c100a-dde4-4f4e-b632-54fd64e02aa2">
