### PR TITLE
TS-60 BUG -  Fix Competition Logos

### DIFF
--- a/prisma/seeds/rugby/teams/index.ts
+++ b/prisma/seeds/rugby/teams/index.ts
@@ -1,7 +1,24 @@
-import { internationalTeams } from './international/index'
-import { superRugbyTeams } from './superRugby/index'
+import type { Competition } from '@prisma/client'
 
-export const competitionTeams = {
-  international: internationalTeams,
-  superRugby: superRugbyTeams,
+import getInternationalTeams from './international'
+import getRugbyChampionShipTeams from './rugbyChampionship'
+import getSuperRugbyTeams from './superRugby'
+
+export type IdsObject = { [key: string]: number }
+
+const getTeams = (competitions: Competition[]) => {
+  const competitionIds = competitions.reduce<IdsObject>((acc, competition) => {
+    acc[competition.key] = competition.id
+    return acc
+  }, {})
+
+   const teams = [
+    ...getInternationalTeams(competitionIds),
+    ...getRugbyChampionShipTeams(competitionIds),
+    ...getSuperRugbyTeams(competitionIds),
+  ]
+
+  return teams
 }
+
+export default getTeams

--- a/prisma/seeds/rugby/teams/rugbyChampionship/index.ts
+++ b/prisma/seeds/rugby/teams/rugbyChampionship/index.ts
@@ -1,12 +1,12 @@
 import type { IdsObject } from '../../players'
 
-const getInternationalTeams = (competitionIds: IdsObject) => {
+const getRugbyChampionShipTeams = (competitionIds: IdsObject) => {
   const {
     international: internationalId,
     rugbyChampionship: rugbyChampionshipId,
   } = competitionIds
 
-  const internationalTeams = [
+  const rugbyChampionshipTeams = [
     {
       key: 'wallabies',
       title: 'Wallabies',
@@ -35,7 +35,7 @@ const getInternationalTeams = (competitionIds: IdsObject) => {
     }
   ]
 
-  return internationalTeams
+  return rugbyChampionshipTeams
 }
 
-export default getInternationalTeams
+export default getRugbyChampionShipTeams

--- a/prisma/seeds/rugby/teams/superRugby/index.ts
+++ b/prisma/seeds/rugby/teams/superRugby/index.ts
@@ -1,86 +1,158 @@
-export const superRugbyTeams = [
-  {
-    key: 'blues',
-    title: 'Blues',
-    primaryColor: '#205CB3',
-    secondaryColor: '#0b1864',
-    tertiaryColor: '#FFFFFF',
-  },
-  {
-    key: 'brumbies',
-    title: 'Brumbies',
-    primaryColor: '#002b54',
-    secondaryColor: '#ffc222',
-    tertiaryColor: '#FFFFFF',
-  },
-  {
-    key: 'chiefs',
-    title: 'Chiefs',
-    primaryColor: '#000000',
-    secondaryColor: '#E1AC2D',
-    tertiaryColor: '#B53931',
-  },
-  {
-    key: 'crusaders',
-    title: 'Crusaders',
-    primaryColor: '#E61D29',
-    secondaryColor: '#000000',
-    tertiaryColor: '#FFFFFF',
-  },
-  {
-    key: 'drua',
-    title: 'Drua',
-    primaryColor: '#151AB7',
-    secondaryColor: '#FFFFFF',
-    tertiaryColor: '',
-  },
-  {
-    key: 'force',
-    title: 'Force',
-    primaryColor: '#1E44CE',
-    secondaryColor: '#FFFFFF',
-    tertiaryColor: '',
-  },
-  {
-    key: 'highlanders',
-    title: 'Highlanders',
-    primaryColor: '#1F2C3F',
-    secondaryColor: '#F2BD43',
-    tertiaryColor: '#7f2852',
-  },
-  {
-    key: 'hurricanes',
-    title: 'Hurricanes',
-    primaryColor: '#FACA03',
-    secondaryColor: '#000000',
-    tertiaryColor: '',
-  },
-  {
-    key: 'moana',
-    title: 'Moana Pasifika',
-    primaryColor: '#09124B',
-    secondaryColor: '#36A9B7',
-    tertiaryColor: '',
-  },
-  {
-    key: 'rebels',
-    title: 'Rebels',
-    primaryColor: '#060662',
-    secondaryColor: '#8D0D4F',
-    tertiaryColor: '',
-  },
-  {
-    key: 'reds',
-    title: 'Reds',
-    primaryColor: '#5E0224',
-    secondaryColor: '#FFFFFF',
-    tertiaryColor: '',
-  },
-  {
-    key: 'waratahs',
-    title: 'Waratahs',
-    primaryColor: '#43B3E6',
-    secondaryColor: '#FFFFFF',
-    tertiaryColor: '#A92A38',
-  },
-]
+import type { IdsObject } from '../../players'
+
+const getSuperRugbyTeams = (competitionIds: IdsObject) => {
+  const {
+    superRugby: superRugbyId,
+  } = competitionIds
+
+  const superRugbyTeams = [
+    {
+      key: 'blues',
+      title: 'Blues',
+      primaryColor: '#205CB3',
+      secondaryColor: '#0b1864',
+      tertiaryColor: '#FFFFFF',
+      competitionTeams: {
+        create: [
+          { competitionId: superRugbyId },
+        ]
+      }
+    },
+    {
+      key: 'brumbies',
+      title: 'Brumbies',
+      primaryColor: '#002b54',
+      secondaryColor: '#ffc222',
+      tertiaryColor: '#FFFFFF',
+      competitionTeams: {
+        create: [
+          { competitionId: superRugbyId },
+        ]
+      }
+    },
+    {
+      key: 'chiefs',
+      title: 'Chiefs',
+      primaryColor: '#000000',
+      secondaryColor: '#E1AC2D',
+      tertiaryColor: '#B53931',
+      competitionTeams: {
+        create: [
+          { competitionId: superRugbyId },
+        ]
+      }
+    },
+    {
+      key: 'crusaders',
+      title: 'Crusaders',
+      primaryColor: '#E61D29',
+      secondaryColor: '#000000',
+      tertiaryColor: '#FFFFFF',
+      competitionTeams: {
+        create: [
+          { competitionId: superRugbyId },
+        ]
+      }
+    },
+    {
+      key: 'drua',
+      title: 'Drua',
+      primaryColor: '#151AB7',
+      secondaryColor: '#FFFFFF',
+      tertiaryColor: '',
+      competitionTeams: {
+        create: [
+          { competitionId: superRugbyId },
+        ]
+      }
+    },
+    {
+      key: 'force',
+      title: 'Force',
+      primaryColor: '#1E44CE',
+      secondaryColor: '#FFFFFF',
+      tertiaryColor: '',
+      competitionTeams: {
+        create: [
+          { competitionId: superRugbyId },
+        ]
+      }
+    },
+    {
+      key: 'highlanders',
+      title: 'Highlanders',
+      primaryColor: '#1F2C3F',
+      secondaryColor: '#F2BD43',
+      tertiaryColor: '#7f2852',
+      competitionTeams: {
+        create: [
+          { competitionId: superRugbyId },
+        ]
+      }
+    },
+    {
+      key: 'hurricanes',
+      title: 'Hurricanes',
+      primaryColor: '#FACA03',
+      secondaryColor: '#000000',
+      tertiaryColor: '',
+      competitionTeams: {
+        create: [
+          { competitionId: superRugbyId },
+        ]
+      }
+    },
+    {
+      key: 'moana',
+      title: 'Moana Pasifika',
+      primaryColor: '#09124B',
+      secondaryColor: '#36A9B7',
+      tertiaryColor: '',
+      competitionTeams: {
+        create: [
+          { competitionId: superRugbyId },
+        ]
+      }
+    },
+    {
+      key: 'rebels',
+      title: 'Rebels',
+      primaryColor: '#060662',
+      secondaryColor: '#8D0D4F',
+      tertiaryColor: '',
+      competitionTeams: {
+        create: [
+          { competitionId: superRugbyId },
+        ]
+      }
+    },
+    {
+      key: 'reds',
+      title: 'Reds',
+      primaryColor: '#5E0224',
+      secondaryColor: '#FFFFFF',
+      tertiaryColor: '',
+      competitionTeams: {
+        create: [
+          { competitionId: superRugbyId },
+        ]
+      }
+    },
+    {
+      key: 'waratahs',
+      title: 'Waratahs',
+      primaryColor: '#43B3E6',
+      secondaryColor: '#FFFFFF',
+      tertiaryColor: '#A92A38',
+      competitionTeams: {
+        create: [
+          { competitionId: superRugbyId },
+        ]
+      }
+    },
+  ]
+
+  return superRugbyTeams
+}
+
+export default getSuperRugbyTeams

--- a/prisma/seeds/teams.ts
+++ b/prisma/seeds/teams.ts
@@ -1,28 +1,9 @@
-import { competitionTeams } from './rugby/teams'
-
 import type { Competition, PrismaClient } from '@prisma/client'
 
-const getCompetitionTeamsArray = (competitionKey: keyof typeof competitionTeams) => {
-  return competitionTeams[competitionKey] || []
-}
+import getTeams from './rugby/teams'
 
 const seedTeams = (prisma: PrismaClient, competitions: Competition[]) => {
-  const teams = competitions.flatMap(competition => {
-    const { id: competitionId, key: competitionKey } = competition
-
-    const competitionTeamsArray = getCompetitionTeamsArray(competitionKey as keyof typeof competitionTeams)
-
-    return competitionTeamsArray.map((competitionTeam) => {
-      return {
-        ...competitionTeam,
-        competitionTeams: {
-          create: [
-            { competitionId }
-          ]
-        }
-      }
-    })
-  })
+  const teams = getTeams(competitions)
 
   const records = teams.map(async team => (
     await prisma.team.upsert({

--- a/public/logos/rugby/index.ts
+++ b/public/logos/rugby/index.ts
@@ -1,2 +1,3 @@
 export * from './international'
+export * from './rugbyChampionship'
 export * from './superRugby'

--- a/public/logos/rugby/rugbyChampionship/index.ts
+++ b/public/logos/rugby/rugbyChampionship/index.ts
@@ -1,0 +1,8 @@
+
+import allBlacksLogo from '../international/allBlacks.png'
+import wallabiesLogo from '../international/wallabies.jpeg'
+
+export const rugbyChampionshipLogos = {
+  allBlacks: allBlacksLogo,
+  wallabies: wallabiesLogo,
+}


### PR DESCRIPTION
Updated Team Seeds here. After doing it I realized again that we can't actually reseed without dropping the db again which we aren't going to do so instead can literally just add the two competition team records in your local db, and I'll add them in staging and production on supabase.

The competitionTeams you are adding is the rugby championship competition id and the teams are allBlacks and wallabies.

Also did what was the purpose of this ticket which was just adding the rugby Championship team logos. Didn't copy the logo files over into the public/logos/rugby/rugbyChampionship folder but just created an index file pointing to the image files in the rugby/international folder so as not to duplicate.